### PR TITLE
fix basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ go get -u github.com/eastwd/jenkins-lint
 
 ## usage
 
-.jlint.tomlをホームディレクトリに作成
+- API tokenを発行
+  - https://[your jenkins url]/user/[your name]/configure
+
+- .jlint.tomlをホームディレクトリに作成
 
 ```
 [Client]
@@ -22,8 +25,8 @@ go get -u github.com/eastwd/jenkins-lint
   TLSVerify = true
 
 [Account]
-  Username = ""
-  Password = ""
+  Username = "your name"
+  APIToken = "your API token"
 
 ```
 

--- a/cmd.go
+++ b/cmd.go
@@ -12,7 +12,7 @@ import (
 var lintCmd = func(c *cli.Context) error {
 	jc := config.Client
 	ja := config.Account
-	client := jenkins.NewClient(jc.Host, jc.TLSVerify, ja.Username, ja.Password)
+	client := jenkins.NewClient(jc.Host, jc.TLSVerify, ja.Username, ja.APIToken)
 
 	//JenkinsのCrumbを取得
 	err := client.FetchCrumb()
@@ -54,7 +54,7 @@ var lintCmdFlags = []cli.Flag{
 }
 
 var configCmd = func(c *cli.Context) error {
-	config.Account.Password = strings.Repeat("*", len(config.Account.Password))
+	config.Account.APIToken = strings.Repeat("*", len(config.Account.APIToken))
 	fmt.Println(config.String())
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -21,7 +21,7 @@ type ClientConfig struct {
 
 type AccountConfig struct {
 	Username string
-	Password string
+	APIToken string
 }
 
 func NewConfig() {
@@ -39,7 +39,10 @@ func DefaultConfig() Config {
 			Host:      defaultHost,
 			TLSVerify: true,
 		},
-		Account: AccountConfig{},
+		Account: AccountConfig{
+			Username: "",
+			APIToken: "",
+		},
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747
 	github.com/urfave/cli v1.20.0
 )
+
+go 1.13


### PR DESCRIPTION
- basic認証に対応
- Anonymous UsersにREAD権限がついてない環境でも、APItokenを設定することで認証ユーザーで実行できる
- configに認証情報をつけない場合は今まで通りAnonymous Usersで実行